### PR TITLE
Include name of source file path in error.

### DIFF
--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -134,7 +134,7 @@ def convert_file(source_file, to, format=None, extra_args=(), encoding='utf-8',
             path.
     """
     if not _identify_path(source_file):
-        raise RuntimeError("source_file is not a valid path")
+        raise RuntimeError(source_file + " is not a valid path")
     format = _identify_format_from_path(source_file, format)
     return _convert_input(source_file, format, 'path', to, extra_args=extra_args,
                           outputfile=outputfile, filters=filters)


### PR DESCRIPTION
Using pypandoc I get very confused with the error message "source_file is not a valid path": I call pypandoc recursively for my documents, so you can imagine it's hard to imagine where the error occurs!

Perhaps there is a good reason for not including the value of source_file in the message, but in my own local version, I find it very useful, so just submitting a pull request to include to (hopefully) make the error message clearer. 