### PR TITLE
Add support for lua filters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Note that for citeproc tests to pass you'll need to have [pandoc-citeproc](https
 * [Kolen Cheung](https://github.com/ickc) - Implement `_get_pandoc_urls` for installing arbitrary version as well as the latest version of pandoc. Minor: README, Travis, setup.py.
 * [Rebecca Heineman](https://github.com/burgerbecky) - Added scanning code for finding pandoc in Windows
 * [Andrew Barraford](https://github.com/abarrafo) - Download destination.
+* [Jesse Widner](https://github.com/jwidner) - Add support for lua filters
  
 ## License
 

--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -274,8 +274,13 @@ def _convert_input(source, format, input_type, to, extra_args=(), outputfile=Non
     if filters is not None:
         if isinstance(filters, string_types):
             filters = filters.split()
-        f = ['--filter=' + x for x in filters]
-        args.extend(f)
+        filter_args = []
+        for f in filters:
+            if f.lower().endswith('.lua'):
+                filter_args.append('--lua-filter=' + f)
+            else:
+                filter_args.append('--filter=' + f)
+        args.extend(filter_args)
 
     # To get access to pandoc-citeproc when we use a included copy of pandoc,
     # we need to add the pypandoc/files dir to the PATH

--- a/smallcaps.lua
+++ b/smallcaps.lua
@@ -1,0 +1,4 @@
+-- taken from: https://pandoc.org/lua-filters.html
+function Strong(elem)
+    return pandoc.SmallCaps(elem.c)
+end

--- a/tests.py
+++ b/tests.py
@@ -271,6 +271,16 @@ class TestPypandoc(unittest.TestCase):
             found = re.search(r'10.1038', written)
             self.assertTrue(found.group() == '10.1038')
 
+    def test_conversion_with_lua_filter(self):
+        # example filter taken from: https://pandoc.org/lua-filters.html
+        filters = ['smallcaps.lua']  # converts bold to smallcaps
+        md_text = '# heading\n**emphasis**'
+        filtered_text = pypandoc.convert_text(md_text, 'html', format='md', filters=filters)
+        import re as re
+        # only properly converted file will have this in it
+        found = re.search(r'smallcaps', filtered_text)
+        self.assertTrue(found.group() == 'smallcaps')
+
     def test_conversion_with_empty_filter(self):
         # we just want to get a temp file name, where we can write to
         filters = ''


### PR DESCRIPTION
Interpret filters with extension .lua as lua filters.
Closes: #155 

Explanation:
Ideally, we would be able to create separate arguments for filters and lua filters.
However, the order that filters appear as arguments to Pandoc actually matters
because it affects the order that the filters are applied to the AST.
Therefore, if a file's name ends in .lua in the filters list, it makes sense to
interpret it as a lua filter.