### PR TITLE
Fix #189: bug with download_pandoc() affecting Windows.

### DIFF
--- a/pypandoc/pandoc_download.py
+++ b/pypandoc/pandoc_download.py
@@ -192,7 +192,7 @@ def download_pandoc(url=None, targetfolder=None, version="latest", quiet=False, 
         if download_folder.endswith('/'):
             download_folder = download_folder[:-1]
 
-        filename = os.path.expanduser(download_folder) + '/' + filename
+        filename = os.path.join(os.path.expanduser(download_folder), filename)
 
     if os.path.isfile(filename):
         print("* Using already downloaded file %s" % (filename))


### PR DESCRIPTION
Make the code that finds the installer less platform dependent by using the os.path module.
Closes: #189 

I confirmed the bug, and then tested the fix on Windows, and it seems to work.