### PR TITLE
Fix #189 by changing the way the path to the installer is constructed

### DIFF
--- a/pypandoc/pandoc_download.py
+++ b/pypandoc/pandoc_download.py
@@ -227,7 +227,7 @@ def download_pandoc(url=None, targetfolder=None, version="latest", quiet=False, 
         if download_folder.endswith('/'):
             download_folder = download_folder[:-1]
 
-        filename = os.path.expanduser(download_folder) + '/' + filename
+        filename = os.path.join(os.path.expanduser(download_folder), filename)
 
     if os.path.isfile(filename):
         print("* Using already downloaded file %s" % (filename))


### PR DESCRIPTION
This fixes issue #189 by using os.path.join instead of manually constructing the filepath to where the installer wold be downloaded to.