### PR TITLE
BUG: Need to add targetfolder to PATH when ensuring installed

### DIFF
--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -565,6 +565,10 @@ def ensure_pandoc_installed(url=None, targetfolder=None, version="latest", quiet
 
     :raises OSError: if pandoc cannot be installed
     """
+    # Append targetfolder to the PATH environment variable so it is found by subprocesses
+    if targetfolder is not None:
+        os.environ["PATH"] = os.environ.get("PATH", "") + os.pathsep + os.path.abspath(os.path.expanduser(targetfolder))
+
     try:
         # Perform the test quietly if asked
         _ensure_pandoc_path(quiet=quiet)


### PR DESCRIPTION
We need to add targetfolder to the PATH environment variable otherwise we will not be able to run pandoc as a subprocess when it is housed this arbitrary download location.

This PR addresses issue as discussed in https://github.com/NicklasTegner/pypandoc/issues/97#issuecomment-886092575.