### PR TITLE
Made it possible to pass multiple files to pandoc - fixes #248

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,23 @@ output = pypandoc.convert_file('somefile.md', 'docx', outputfile="somefile.docx"
 assert output == ""
 ```
 
+
+It's also possible to specify multiple input files to pandoc, either as absolute paths, relative paths or file patterns.
+
+```python
+import pypandoc
+
+# convert all markdown files in a chapters/ subdirectory.
+pypandoc.convert_file('chapters/*.md', 'docx', outputfile="somefile.docx")
+
+# convert all markdown files in the book1 and book2 directories.
+pypandoc.convert_file(['book1/*.md', 'book2/*.md'], 'docx', outputfile="somefile.docx")
+
+# convert the front from another drive, and all markdown files in the chapter directory.
+pypandoc.convert_file(['D:/book_front.md', 'book2/*.md'], 'docx', outputfile="somefile.docx")
+```
+
+
 In addition to `format`, it is possible to pass `extra_args`.
 That makes it possible to access various pandoc options easily.
 

--- a/tests.py
+++ b/tests.py
@@ -193,6 +193,25 @@ class TestPypandoc(unittest.TestCase):
             received = pypandoc.convert_file(file_name, 'rst')
             self.assertEqualExceptForNewlineEnd(expected, received)
 
+    def test_basic_conversion_from_multiple_files(self):
+        with closed_tempfile('.md', text='some title') as file_name1:
+            with closed_tempfile('.md', text='some title') as file_name2:
+                expected = '<p>some title</p>\n<p>some title</p>'
+                received = pypandoc.convert_file([file_name1,file_name2], 'html')
+                self.assertEqualExceptForNewlineEnd(expected, received)
+
+    def test_basic_conversion_from_file_pattern(self):
+        received = pypandoc.convert_file("./*.md", 'html')
+        received = received.lower()
+        assert "making a release" in received
+        assert "pypandoc provides a thin wrapper" in received
+
+    def test_basic_conversion_from_file_pattern_with_input_list(self):
+        received = pypandoc.convert_file(["./*.md", "./*.md"], 'html')
+        received = received.lower()
+        assert "making a release" in received
+        assert "pypandoc provides a thin wrapper" in received
+
     @unittest.skipIf(sys.platform.startswith("win"), "File based urls do not work on windows: "
                                                      "https://github.com/jgm/pandoc/issues/4613")
     def test_basic_conversion_from_file_url(self):


### PR DESCRIPTION
This pr makes it possible to pass multiple files to pandoc in various ways.

Examples (from the updated readme)

```python
import pypandoc

# convert all markdown files in a chapters/ subdirectory.
pypandoc.convert_file('chapters/*.md', 'docx', outputfile="somefile.docx")

# convert all markdown files in the book1 and book2 directories.
pypandoc.convert_file(['book1/*.md', 'book2/*.md'], 'docx', outputfile="somefile.docx")

# convert the front from another drive, and all markdown files in the chapter directory.
pypandoc.convert_file(['D:/book_front.md', 'book2/*.md'], 'docx', outputfile="somefile.docx")
```


This fixes #248 

simonv3