### PR TITLE
BUG+REL: Restore Python2.7 support

### DIFF
--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -15,7 +15,7 @@ from .pandoc_download import DEFAULT_TARGET_FOLDER, download_pandoc
 from .py3compat import cast_bytes, cast_unicode, string_types, url2path, urlparse
 
 __author__ = u'Juho Vepsäläinen'
-__version__ = '1.7.4'
+__version__ = '1.7.5'
 __license__ = 'MIT'
 __all__ = ['convert', 'convert_file', 'convert_text',
            'get_pandoc_formats', 'get_pandoc_version', 'get_pandoc_path',

--- a/pypandoc/pandoc_download.py
+++ b/pypandoc/pandoc_download.py
@@ -18,6 +18,12 @@ except ImportError:
 
 from .handler import _check_log_handler
 
+try:
+    FileNotFoundError
+except NameError:
+    # Python <3.5
+    FileNotFoundError = IOError
+
 logger = logging.getLogger(__name__.split('.')[0])
 
 DEFAULT_TARGET_FOLDER = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pypandoc"
-version = "1.7.4"
+version = "1.7.5"
 description = "Thin wrapper for pandoc"
 authors = ["NicklasTegner <NicklasMCHD@live.dk>"]
 license = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,7 @@ setup(
         'Programming Language :: Python',
         'Topic :: Text Processing',
         'Topic :: Text Processing :: Filters',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
Restores Python 2.7 support for a 1.7.5 hotfix before Python 2.7 support is dropped.

Tested on Python 2.7.18 on Ubuntu 20.04.4 with the following shell code:
```
sudo apt-get remove pandoc
rm -rf test
mkdir test
python
```
```python
import os
import pypandoc
dirname = os.path.join(os.getcwd(), "test")
pypandoc.download_pandoc(targetfolder=dirname)
os.environ["PATH"] += os.pathsep + dirname
pypandoc.convert_file("test.md", "rst", outputfile="test/test.rst")
pypandoc.convert_file("README.md", "rst", outputfile="test/README.rst")
exit
```
```sh
PATH="${PATH}:${PWD}/test"
python tests.py
```

Once merged, the py27support branch needs to be built as a wheel and released as 1.7.5 on PyPI.