### PR TITLE
REL: Officially drop python2.7 support

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2,7 +2,7 @@ package = []
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^2.7 || ^3.6"
+python-versions = "^3.6"
 content-hash = "33dea47884f399737763b1c9e7c9c7a57b29c3995d193fe5fc74925a54a2a96c"
 
 [metadata.files]

--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -17,7 +17,7 @@ from .pandoc_download import DEFAULT_TARGET_FOLDER, download_pandoc
 from .py3compat import cast_bytes, cast_unicode, string_types, url2path, urlparse
 
 __author__ = u'Juho Vepsäläinen'
-__version__ = '1.7.5'
+__version__ = '1.8.dev0'
 __license__ = 'MIT'
 __all__ = ['convert_file', 'convert_text',
            'get_pandoc_formats', 'get_pandoc_version', 'get_pandoc_path',

--- a/pypandoc/pandoc_download.py
+++ b/pypandoc/pandoc_download.py
@@ -18,12 +18,6 @@ except ImportError:
 
 from .handler import _check_log_handler
 
-try:
-    FileNotFoundError
-except NameError:
-    # Python <3.5
-    FileNotFoundError = IOError
-
 logger = logging.getLogger(__name__.split('.')[0])
 
 DEFAULT_TARGET_FOLDER = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pypandoc"
-version = "1.7.5"
+version = "1.8.dev0"
 description = "Thin wrapper for pandoc"
 authors = ["NicklasTegner <NicklasMCHD@live.dk>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,6 @@ classifiers = [
         'Programming Language :: Python',
         'Topic :: Text Processing',
         'Topic :: Text Processing :: Filters',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
@@ -41,7 +39,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^2.7 || ^3.6"
+python = "^3.6"
 
 [tool.poetry.dev-dependencies]
 

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
     author_email = 'bebraw@gmail.com',
     packages = ['pypandoc'],
     package_data={'pypandoc': ['files/*']},
+    python_requires=">=3.6",
     install_requires = ['setuptools', 'pip>=8.1.0', 'wheel>=0.25.0'],
     classifiers=[
         'Development Status :: 4 - Beta',
@@ -98,8 +99,6 @@ setup(
         'Programming Language :: Python',
         'Topic :: Text Processing',
         'Topic :: Text Processing :: Filters',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
Followup to #262, and closes #260.

Indicate that Python 2.7 support is dropped from releases after 1.7.5 (i.e. 1.8.0 and onwards).

I didn't change the Dockerfile (which uses python 2.7), remove the imports from `__future__`, or tidy up the py3compat stuff though.