### PR TITLE
Handle pandoc logging returning two unknown log levels

### DIFF
--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -396,14 +396,14 @@ def _classify_pandoc_logging(raw, default_level="WARNING"):
     # that does not conform to the pandoc standard, use the default_level 
     # value instead.
     
+    # Available pandoc logging levels adapted from:
+    # https://github.com/jgm/pandoc/blob/5e1249481b2e3fc27e845245a0c96c3687a23c3d/src/Text/Pandoc/Logging.hs#L44
     def get_python_level(pandoc_level):
         
-        level_map = {"CRITICAL": 50,
-                     "ERROR": 40,
+        level_map = {"ERROR": 40,
                      "WARNING": 30,
                      "INFO": 20,
-                     "DEBUG": 10,
-                     "NOTSET": 0}
+                     "DEBUG": 10}
         
         if pandoc_level not in level_map:
             level = level_map[default_level]

--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -437,7 +437,7 @@ def _classify_pandoc_logging(raw, default_level="WARNING"):
         
         log_msgs.append(msg)
     
-    yield get_python_level(pandoc_level), "\n".join(log_msgs)
+    return get_python_level(pandoc_level), "\n".join(log_msgs)
 
 
 def _get_base_format(format):

--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -390,10 +390,11 @@ def _convert_input(source, format, input_type, to, extra_args=(),
 
 
 def _classify_pandoc_logging(raw, default_level="WARNING"):
-    # Process raw and yeild the contained logging levels and messages.
+    # Process raw and yield the contained logging levels and messages.
     # Assumes that the messages are formatted like "[LEVEL] message". If the 
-    # first message does not have a level or the level does not conform to the
-    # pandoc standard, use the default_level value instead.
+    # first message does not have a level or any other message has a level 
+    # that does not conform to the pandoc standard, use the default_level 
+    # value instead.
     
     def get_python_level(pandoc_level):
         

--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -392,14 +392,24 @@ def _convert_input(source, format, input_type, to, extra_args=(),
 def _classify_pandoc_logging(raw, default_level="WARNING"):
     # Process raw and yeild the contained logging levels and messages.
     # Assumes that the messages are formatted like "[LEVEL] message". If the 
-    # first message does not have a level, use the default_level value instead.
+    # first message does not have a level or the level does not conform to the
+    # pandoc standard, use the default_level value instead.
     
-    level_map = {"CRITICAL": 50,
-                 "ERROR": 40,
-                 "WARNING": 30,
-                 "INFO": 20,
-                 "DEBUG": 10,
-                 "NOTSET": 0}
+    def get_python_level(pandoc_level):
+        
+        level_map = {"CRITICAL": 50,
+                     "ERROR": 40,
+                     "WARNING": 30,
+                     "INFO": 20,
+                     "DEBUG": 10,
+                     "NOTSET": 0}
+        
+        if pandoc_level not in level_map:
+            level = level_map[default_level]
+        else:
+            level = level_map[pandoc_level]
+        
+        return level
     
     msgs = raw.split("\n")
     first = msgs.pop(0)
@@ -408,29 +418,25 @@ def _classify_pandoc_logging(raw, default_level="WARNING"):
     
     # Use the default if the first message doesn't have a level
     if search is None:
-        level = default_level
+        pandoc_level = default_level
     else:
-        level = first[search.start(1):search.end(1)]
+        pandoc_level = first[search.start(1):search.end(1)]
     
-    log_msgs = [first.replace('[{}] '.format(level), '')]
-    
-    if level not in level_map:
-        level = default_level
-    
+    log_msgs = [first.replace('[{}] '.format(pandoc_level), '')]
     
     for msg in msgs:
         
         search = re.search(r"\[(.*?)\]", msg)
         
         if search is not None:
-            yield level_map[level], "\n".join(log_msgs)
-            level = msg[search.start(1):search.end(1)]
-            log_msgs = [msg.replace('[{}] '.format(level), '')]
+            yield get_python_level(pandoc_level), "\n".join(log_msgs)
+            pandoc_level = msg[search.start(1):search.end(1)]
+            log_msgs = [msg.replace('[{}] '.format(pandoc_level), '')]
             continue
         
         log_msgs.append(msg)
     
-    yield level_map[level], "\n".join(log_msgs)
+    yield get_python_level(pandoc_level), "\n".join(log_msgs)
 
 
 def _get_base_format(format):

--- a/pypandoc/__init__.py
+++ b/pypandoc/__init__.py
@@ -437,7 +437,7 @@ def _classify_pandoc_logging(raw, default_level="WARNING"):
         
         log_msgs.append(msg)
     
-    return get_python_level(pandoc_level), "\n".join(log_msgs)
+    yield get_python_level(pandoc_level), "\n".join(log_msgs)
 
 
 def _get_base_format(format):

--- a/tests.py
+++ b/tests.py
@@ -337,10 +337,12 @@ class TestPypandoc(unittest.TestCase):
     def test_classify_pandoc_logging_invalid_level(self):
         
         test = ("[WARN] This is some message on\ntwo lines\n"
-                "[ERROR] This is a second message.")
-        expected_levels = [30, 40]
+                "[ERR] This is a second message.\n"
+                "[ERROR] This is a third message.")
+        expected_levels = [30, 30, 40]
         expected_msgs = ["This is some message on\ntwo lines",
-                         "This is a second message."]
+                         "This is a second message.",
+                         "This is a third message."]
         
         for i, (l, m) in enumerate(pypandoc._classify_pandoc_logging(test)):
             self.assertEqual(expected_levels[i], l)


### PR DESCRIPTION
This is a follow up to #271, which deals with the case where pandoc produces more than one logging message with non-standard levels, followed by another log message. For example, the following pandoc output still produced a `KeyError`:

```
[WARN] This is some message on
two lines
[ERR] This is a second message.
[ERROR] This is a third message.
```

This PR updates the `_classify_pandoc_logging` function and the `test_classify_pandoc_logging_invalid_level` test to correctly handle this case.

I have also updated the `level_map` dictionary which converts the pandoc levels to python codes, so that it only contains levels [formally used by pandoc](https://github.com/jgm/pandoc/blob/5e1249481b2e3fc27e845245a0c96c3687a23c3d/src/Text/Pandoc/Logging.hs#L44).

Fixes #269 