### PR TITLE
setup.py: Use setup_requires for setup.py requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
     packages = ['pypandoc'],
     package_data={'pypandoc': ['files/*']},
     python_requires=">=3.6",
-    install_requires = ['setuptools', 'pip>=8.1.0', 'wheel>=0.25.0'],
+    setup_requires = ['setuptools', 'pip>=8.1.0', 'wheel>=0.25.0'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
The dependecies on setuptools/pip/wheel were required for the setup.py
to run and not the actual source code to run.

install_requires won't work here because those are meant for the source
to run.
According to the packaging specification, setup_requires should be
provided for any dependencies needed by the setup.py to run.
Reference: https://pip.pypa.io/en/stable/reference/build-system/#controlling-setup-requires
Example: https://github.com/slundberg/shap/blob/v0.40.0/setup.py#L226

Fixes https://github.com/NicklasTegner/pypandoc/issues/198